### PR TITLE
Adding symlink to README.md to fix build failure

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
This fixes the following error on build --

```
root@host1:~/bob/ganeti-instance-cobbler# make
make: *** No rule to make target `README', needed by `all-am'.  Stop.
```
